### PR TITLE
add new public sigs to robotproxy

### DIFF
--- a/app/robotproxy.ts
+++ b/app/robotproxy.ts
@@ -33,6 +33,14 @@ export class RobotProxy {
         this.resolvers[this.seq] = {resolve, reject};
         return prom;
     }
+
+    public getTurn(state: wire.StateMessageArguments): Promise<wire.ActionMessage> {
+        return this.send('state', state);
+    }
+
+    public destroy(): void {
+        this.worker.terminate();
+    }
 }
 
 export default RobotProxy;


### PR DESCRIPTION
`getTurn` and `destroy` - `getTurn` does what it says on the tin, given the word state, it returns a promise to the message with the actions for the turn. `destroy` terminates the worker (not sure if we want more validation around this)
